### PR TITLE
use numpy.issubdtype instead of equality for numericness

### DIFF
--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -14,7 +14,7 @@ class TestEncoders(unittest.TestCase):
     def verify_numeric(self, X_test):
         for dt in X_test.dtypes:
             numeric = False
-            if dt == int or dt == float:
+            if np.issubdtype(dt, int) or np.issubdtype(dt, float):
                 numeric = True
             self.assertTrue(numeric)
 


### PR DESCRIPTION
Apparently, windows `int` and `float` are not `==` to most dtypes, causing two test fails:
https://ci.appveyor.com/project/conda-forge/staged-recipes/build/1.0.4847/job/iqs0wu1u7jcamxs3#L418

This adds use of `numpy.issubdtype` for an (apparently) more robust comparison.